### PR TITLE
try old sum to nail down nasty reboot problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM metalstack/builder:latest as builder
 
-FROM r.metal-stack.io/metal/supermicro:2.5.2 as sum
+FROM r.metal-stack.io/metal/supermicro:2.5.0 as sum
 
 FROM golang:1.14-buster as initrd-builder
 ENV UROOT_GIT_SHA_OR_TAG=v7.0.0


### PR DESCRIPTION
Roll back to sum 2.5.0 to check if with this version a fresh installed machine will be set to boot from hd afterwards