### PR TITLE
Clear all partition signatures on a devices before creating new

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ ramdisk:
 		-files="/sbin/mdadm:sbin/mdadm" \
 		-files="/sbin/mdmon:sbin/mdmon" \
 		-files="/sbin/sgdisk:sbin/sgdisk" \
+		-files="/sbin/wipefs:sbin/wipefs" \
 		-files="/etc/ssl/certs/ca-certificates.crt:etc/ssl/certs/ca-certificates.crt" \
 		-files="/usr/lib/x86_64-linux-gnu/libnss_files.so:lib/libnss_files.so.2" \
 		-files="passwd:etc/passwd" \

--- a/cmd/storage/filesystem.go
+++ b/cmd/storage/filesystem.go
@@ -113,9 +113,15 @@ func (f *Filesystem) createPartitions() error {
 			}
 		}
 		if disk.Device != nil {
+			log.Info("wipe existing partition signatures")
+			err := os.ExecuteCommand(command.WIPEFS, "--all", *disk.Device)
+			if err != nil {
+				log.Error("wipe existing partition signatures failed", "error", err)
+				return fmt.Errorf("unable wipe existing partitions on %s %w", *disk.Device, err)
+			}
 			opts = append(opts, *disk.Device)
 			log.Info("sgdisk create partitions", "command", opts)
-			err := os.ExecuteCommand(command.SGDisk, opts...)
+			err = os.ExecuteCommand(command.SGDisk, opts...)
 			if err != nil {
 				log.Error("sgdisk creating partitions failed", "error", err)
 				return fmt.Errorf("unable to create partitions on %s %w", *disk.Device, err)

--- a/cmd/storage/filesystem.go
+++ b/cmd/storage/filesystem.go
@@ -113,7 +113,7 @@ func (f *Filesystem) createPartitions() error {
 			}
 		}
 		if disk.Device != nil {
-			log.Info("wipe existing partition signatures")
+			log.Info("wipe existing partition signatures", "command", command.WIPEFS+" --all"+" "+*disk.Device)
 			err := os.ExecuteCommand(command.WIPEFS, "--all", *disk.Device)
 			if err != nil {
 				log.Error("wipe existing partition signatures failed", "error", err)

--- a/pkg/os/command/commands.go
+++ b/pkg/os/command/commands.go
@@ -21,6 +21,7 @@ const (
 	SGDisk   = "sgdisk"
 	SSHD     = "sshd"
 	SUM      = "sum"
+	WIPEFS   = "wipefs"
 )
 
 var commands = []string{
@@ -39,6 +40,7 @@ var commands = []string{
 	SGDisk,
 	SSHD,
 	SUM,
+	WIPEFS,
 }
 
 // CommandsExist check that all required binaries are installed in the initrd.


### PR DESCRIPTION
This tries to solve #61 in a simple way by clearing still existing signatures of all kind from the block device. This cannot help if the reason for #61 is a hardware defect on the block device.

- [x] tested in test-env with c1-xlarge
- [ ] tested in test-env with s2-xlarge