### PR TITLE
only reboot every 3 days and spread in one day

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func Run(spec *Specification, hal hal.InBand) (*event.EventEmitter, error) {
 	}
 
 	// Reboot after 24Hours if no allocation was requested.
-	go kernel.AutoReboot(24*time.Hour, func() {
+	go kernel.AutoReboot(3*24*time.Hour, 24*time.Hour, func() {
 		eventEmitter.Emit(event.ProvisioningEventPlannedReboot, "autoreboot after 24h")
 	})
 

--- a/pkg/kernel/kernel.go
+++ b/pkg/kernel/kernel.go
@@ -136,7 +136,7 @@ func Watchdog() {
 	}
 }
 
-// AutoReboot will start a timer and reboot after given duration a random variation of 1/3rd is added
+// AutoReboot will start a timer and reboot after given duration a random variation spread is added
 func AutoReboot(after, spread time.Duration, callback func()) {
 	log.Info("autoreboot set to", "after", after, "spread", spread)
 	spreadMinutes, err := rand.Int(rand.Reader, big.NewInt(int64(spread.Minutes())))


### PR DESCRIPTION
If a lot of machines powered on at the same time, they will also reboot every 24 hours at the exact same time which causes a lot of link up / link down events on the switches. This might as a consequence stress the `switchd` on the switch itself and eventually cause some small network hiccups for services connected to this switch.


From test environment:
```
INFO[04-14|05:16:31] autoreboot set to                        after=72h0m0s spread=24h0m0s caller=kernel.go:141                                                                                                                                                                           
INFO[04-14|05:16:31] autoreboot with spread                   after=95h57m0s caller=kernel.go:150                                                                                                                                                                                         

```