### PR TITLE
Add firewaldistance to InstallerConfig

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -220,19 +220,20 @@ func (h *hammer) writeInstallerConfig(machine *models.V1MachineResponse, rootUUi
 	}
 
 	y := &api.InstallerConfig{
-		Hostname:      *alloc.Hostname,
-		SSHPublicKey:  sshPubkeys,
-		Networks:      alloc.Networks,
-		MachineUUID:   h.spec.MachineUUID,
-		Password:      h.spec.ConsolePassword,
-		Console:       console,
-		Timestamp:     time.Now().Format(time.RFC3339),
-		Nics:          h.onlyNicsWithNeighbors(machine.Hardware.Nics),
-		VPN:           alloc.Vpn,
-		Role:          *alloc.Role,
-		RaidEnabled:   raidEnabled,
-		RootUUID:      rootUUiD,
-		FirewallRules: alloc.FirewallRules,
+		Hostname:         *alloc.Hostname,
+		SSHPublicKey:     sshPubkeys,
+		Networks:         alloc.Networks,
+		MachineUUID:      h.spec.MachineUUID,
+		Password:         h.spec.ConsolePassword,
+		Console:          console,
+		Timestamp:        time.Now().Format(time.RFC3339),
+		Nics:             h.onlyNicsWithNeighbors(machine.Hardware.Nics),
+		VPN:              alloc.Vpn,
+		Role:             *alloc.Role,
+		RaidEnabled:      raidEnabled,
+		RootUUID:         rootUUiD,
+		FirewallRules:    alloc.FirewallRules,
+		FirewallDistance: 0,
 	}
 
 	yamlContent, err := yaml.Marshal(y)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,6 +40,8 @@ type InstallerConfig struct {
 	RootUUID string `yaml:"root_uuid"`
 	// FirewallRules if not empty firewall rules to enforce
 	FirewallRules *models.V1FirewallRules `yaml:"firewall_rules"`
+	// FirewallDistance is used by the firewall-controller only not by machines
+	FirewallDistance uint8 `yaml:"firewall_distance"`
 }
 
 // FIXME legacy structs remove once old images are gone


### PR DESCRIPTION
## Description

In order for the firewall controller to give the metal-network the distance of its firewall the InstallerConfig which is used by the fc needs to be updated to include the firewallDistance.