### PR TITLE
Downgrade u-root to enable ctrl-c again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN curl -fLsS https://sourceforge.net/projects/e1000/files/ice%20stable/${ICE_V
 
 # ipmitool from bookworm is broken and returns with error on most commands, seems fixed
 # sgdisk from debian:13 is broken and creates a corrupt GPT partition layout
-FROM golang:1.25-bookworm AS initrd-builder
-ENV UROOT_GIT_SHA_OR_TAG=v0.15.0
+FROM golang:1.24-bookworm AS initrd-builder
+ENV UROOT_GIT_SHA_OR_TAG=v0.14.0
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	ca-certificates \


### PR DESCRIPTION
## Description

Pressing `ctrl-c` does not abort metal-hammer anymore, i suspect it is only related to the initrd creation.

This replaces #173 

Works in Test

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
