### PR TITLE
Remove legacy code regarding `disk.json`

### DIFF
--- a/cmd/storage/filesystem.go
+++ b/cmd/storage/filesystem.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	gos "os"
@@ -89,11 +88,6 @@ func (f *Filesystem) Run() error {
 		return fmt.Errorf("mount special filesystems failed:%w", err)
 	}
 
-	// TODO legacy image support, can be removed once all images in use do no depend on disk.json anymore
-	err = f.createDiskJSON()
-	if err != nil {
-		return fmt.Errorf("disk.json creation failed:%w", err)
-	}
 	return nil
 }
 func (f *Filesystem) Umount() {
@@ -472,26 +466,6 @@ func (f *Filesystem) umountFilesystems() {
 
 func (f *Filesystem) CreateFSTab() error {
 	return f.fstabEntries.write(f.log, f.chroot)
-}
-
-func (f *Filesystem) createDiskJSON() error {
-	configdir := path.Join(f.chroot, "etc", "metal")
-	destination := path.Join(configdir, "disk.json")
-
-	if _, err := gos.Stat(configdir); err != nil && gos.IsNotExist(err) {
-		if err := gos.MkdirAll(configdir, 0755); err != nil {
-			return err
-		}
-	} else if err != nil {
-		return err
-	}
-
-	j, err := json.MarshalIndent(f.disk, "", "  ")
-	if err != nil {
-		return fmt.Errorf("unable to marshal to json %w", err)
-	}
-	f.log.Info("create legacy disk.json", "content", string(j))
-	return gos.WriteFile(destination, j, 0600)
 }
 
 func mountFs(log *slog.Logger, chroot string, fs models.V1Filesystem) (string, error) {


### PR DESCRIPTION
## Description

I think `disk.json` is not used anymore by `metal-images`, right? This pull request removes legacy code.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- NONE used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
