### PR TITLE
fix: sync to disk after unmounting, before kexec, so late writes survive failed unmounts

### DIFF
--- a/cmd/storage/filesystem.go
+++ b/cmd/storage/filesystem.go
@@ -468,6 +468,12 @@ func (f *Filesystem) umountFilesystems() {
 			f.log.Error("unable to unmount", "path", m, "error", err)
 		}
 	}
+	// Unmount errors above are tolerated, but a failed unmount leaves dirty pages behind and
+	// the machine kexecs right after this - and kexec does NOT flush the page cache. Without
+	// this global sync, late writes (most prominently /etc/fstab, written after install-go)
+	// are silently lost and the installed OS boots with the image's placeholder fstab, a
+	// read-only root and none of the layout's extra mounts.
+	syscall.Sync()
 }
 
 func (f *Filesystem) CreateFSTab() error {


### PR DESCRIPTION
The fstab is written after install-go, moments before the filesystems are unmounted and the machine kexecs into the installed OS. Unmount errors are tolerated (logged only) and kexec does not flush the page cache, so whenever an unmount fails the fstab write is silently lost: the installed OS then boots with the image's placeholder fstab, leaving the root read-only and the layout's extra filesystems (e.g. /var/lib) unmounted.

Observed on Supermicro H13SRD-F with a filesystemlayout carrying a /var/lib partition: roughly every other install lost the fstab, verified by capturing the install log over SOL (correct 'write fstab' content) and comparing with the booted system (placeholder fstab, same root UUID as the kexec cmdline).

Fix: a single global sync() after the unmount loop - one choke-point that flushes every dirty page (fstab, boot-info, ESP contents) whether or not the unmounts succeeded. On Linux sync(2) blocks until completion.

This is a quickfix and I'm not sure if we should merge this or go straight for a proper and durable solution.

#### Used AI-Tools ✨

Claude Code - Fable 5
