### PR TITLE
Sync before umount filesystems

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -470,6 +470,7 @@ func (h *hammer) convertConfigs(machine *models.V1MachineResponse, rootUUiD stri
 		DnsServers:     dnsservers,
 		NtpServers:     ntpservers,
 		Vpn:            vpn,
+		// FilesystemLayout is not required here because os-installer does not process it.
 	}
 
 	h.log.Info("generated apiv2 allocation", "allocation", machineAllocation)

--- a/cmd/storage/filesystem.go
+++ b/cmd/storage/filesystem.go
@@ -428,16 +428,16 @@ func (f *Filesystem) mountSpecialFilesystems() error {
 }
 
 func (f *Filesystem) umountFilesystems() {
-	for index := len(specialMounts) - 1; index >= 0; index-- {
-		m := filepath.Join(f.chroot, specialMounts[index].target)
+	for _, specialMount := range slices.Backward(specialMounts) {
+		m := filepath.Join(f.chroot, specialMount.target)
 		f.log.Info("unmounting", "mountpoint", m)
 		err := syscall.Unmount(m, syscall.MNT_FORCE)
 		if err != nil {
 			f.log.Error("unable to unmount", "path", m, "error", err)
 		}
 	}
-	for index := len(f.mounts) - 1; index >= 0; index-- {
-		m := f.mounts[index]
+	for _, m := range slices.Backward(f.mounts) {
+
 		if m == "" {
 			continue
 		}
@@ -447,6 +447,13 @@ func (f *Filesystem) umountFilesystems() {
 			f.log.Error("unable to unmount", "path", m, "error", err)
 		}
 	}
+
+	// Unmount errors above are tolerated, but a failed unmount leaves dirty pages behind and
+	// the machine kexecs right after this - and kexec does NOT flush the page cache. Without
+	// this global sync, late writes (most prominently /etc/fstab, written after install-go)
+	// are silently lost and the installed OS boots with the image's placeholder fstab, a
+	// read-only root and none of the layout's extra mounts.
+	syscall.Sync()
 }
 
 func (f *Filesystem) CreateFSTab() error {


### PR DESCRIPTION
## Description

We observe read-only filesystems after installation finished and kexec into the os on certain newer machines.
This might be because of faster hardware, try to avoid this by flushing fs content before umounting.

Related: #186 
Eventually replaces: #185 

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
