### PR TITLE
fix: strict filesystem unmount before kexec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ metal-hammer
 metal-hammer-kernel.md5
 metal-hammer.tar
 metal-hammer-initrd.img.lz4
+metal-hammer-initrd.img.lz4.md5
 metal-hammer-kernel

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -56,7 +56,10 @@ func (h *hammer) Install(machine *models.V1MachineResponse) (*installerv1.Bootin
 		return nil, err
 	}
 
-	s.Umount()
+	err = s.Umount()
+	if err != nil {
+		return nil, err
+	}
 
 	return info, nil
 }

--- a/cmd/storage/filesystem.go
+++ b/cmd/storage/filesystem.go
@@ -86,8 +86,8 @@ func (f *Filesystem) Run() error {
 
 	return nil
 }
-func (f *Filesystem) Umount() {
-	f.umountFilesystems()
+func (f *Filesystem) Umount() error {
+	return f.umountFilesystems()
 }
 
 func (f *Filesystem) createPartitions() error {
@@ -427,13 +427,13 @@ func (f *Filesystem) mountSpecialFilesystems() error {
 	return nil
 }
 
-func (f *Filesystem) umountFilesystems() {
+func (f *Filesystem) umountFilesystems() error {
 	for index := len(specialMounts) - 1; index >= 0; index-- {
 		m := filepath.Join(f.chroot, specialMounts[index].target)
 		f.log.Info("unmounting", "mountpoint", m)
-		err := syscall.Unmount(m, syscall.MNT_FORCE)
+		err := syscall.Unmount(m, 0)
 		if err != nil {
-			f.log.Error("unable to unmount", "path", m, "error", err)
+			return fmt.Errorf("unable to unmount %s: %w", m, err)
 		}
 	}
 	for index := len(f.mounts) - 1; index >= 0; index-- {
@@ -442,11 +442,12 @@ func (f *Filesystem) umountFilesystems() {
 			continue
 		}
 		f.log.Info("unmounting", "mountpoint", m)
-		err := syscall.Unmount(m, syscall.MNT_FORCE)
+		err := syscall.Unmount(m, 0)
 		if err != nil {
-			f.log.Error("unable to unmount", "path", m, "error", err)
+			return fmt.Errorf("unable to unmount %s: %w", m, err)
 		}
 	}
+	return nil
 }
 
 func (f *Filesystem) CreateFSTab() error {


### PR DESCRIPTION
Unmount failures during the post-installation teardown were tolerated (logged and ignored) and the unmounts used MNT_FORCE. Both are wrong:

- per umount(2), MNT_FORCE only asks network filesystems (nfs, cifs, fuse, 9p, ceph, lustre) to abort in-flight requests, 'could cause data loss', and is a no-op on local filesystems - it cannot overcome EBUSY.
- the machine kexecs right after the teardown, and kexec does not flush the page cache ('reboot doesn't sync: do that yourself before calling this', kernel/reboot.c). A tolerated unmount failure therefore silently loses the latest writes. Observed in the field (v0.14.1 era, Supermicro H13SRD-F): installed machines booting with the OS image's placeholder /etc/fstab - the real fstab is written moments before the teardown - leaving a read-only root and the filesystemlayout's extra mounts (e.g. /var/lib) unmounted, which broke FRR on firewalls.

A successful unmount flushes all dirty pages and marks the filesystem clean by itself, so exactly two outcomes are sound: unmounted (and therefore durable), or a failed installation that is reported and retried. Prior art: Ignition's umount stage also treats unmount failure as fatal; Talos and coreos-installer unmount without MNT_FORCE.

fixes #186 

#### Used AI-Tools ✨

Claude Code Fable 5 was used to identify the issue and test fixes. Code has been reviewed line-by-line by myself.