### PR TITLE
fix: report failed installations to metal-api instead of skipping the report

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -158,26 +159,26 @@ func Run(log *slog.Logger, spec *Specification, hal hal.InBand) (*event.EventEmi
 func (h *hammer) installImage(eventEmitter *event.EventEmitter, bootService v1.BootServiceClient, m *models.V1MachineResponse) error {
 	eventEmitter.Emit(event.ProvisioningEventInstalling, "start installation")
 	installationStart := time.Now()
-	info, err := h.Install(m)
-
-	// FIXME, must not return here.
-	if err != nil {
-		return fmt.Errorf("install %w ", err)
-	}
+	info, installErr := h.Install(m)
 
 	rep := &report.Report{
 		MachineUUID:     h.spec.MachineUUID,
 		Client:          bootService,
 		ConsolePassword: h.spec.ConsolePassword,
-		Initrd:          info.Initrd,
-		Cmdline:         info.Cmdline,
-		Kernel:          info.Kernel,
-		BootloaderID:    info.BootloaderID,
-		InstallError:    err,
+		InstallError:    installErr,
 		Log:             h.log,
 	}
+	// info is nil when the installation failed
+	if info != nil {
+		rep.Initrd = info.Initrd
+		rep.Cmdline = info.Cmdline
+		rep.Kernel = info.Kernel
+		rep.BootloaderID = info.BootloaderID
+	}
 
-	err = rep.ReportInstallation()
+	reportErr := rep.ReportInstallation()
+
+	err := errors.Join(installErr, reportErr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The installation report was skipped entirely when the installation failed (the old FIXME): metal-api never learned Success=false or the error message, even though the report plumbing fully supports it (InstallError -> Success, Message). Now the report is always attempted; a failed installation still fails installImage, and a failed report upload is joined onto the installation error.